### PR TITLE
Change navigation properties in audio entities

### DIFF
--- a/src/Domain/Models/Audio/Song.cs
+++ b/src/Domain/Models/Audio/Song.cs
@@ -19,7 +19,7 @@ namespace Domain.Models.Audio
         /// <param name="id"></param>
         private Song(Guid id) : base(id) { }
 
-        private HashSet<PerformerSong> _performers;
+        private HashSet<SongPerformer> _performers;
         private HashSet<AlbumSong> _albums;
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Domain.Models.Audio
             SongLyric = songLyric;
             GenreID = genreID;
             LanguageID = languageID;
-            _performers = new HashSet<PerformerSong>();
+            _performers = new HashSet<SongPerformer>();
             _albums = new HashSet<AlbumSong>();
         }
 
@@ -79,7 +79,7 @@ namespace Domain.Models.Audio
         /// <summary>
         /// Gets the collection of performers associated with the song.
         /// </summary>
-        public virtual ICollection<PerformerSong> Performers => _performers.ToList();
+        public virtual ICollection<SongPerformer> Performers => _performers.ToList();
 
         /// <summary>
         /// Gets the collection of albums associated with the song.
@@ -174,41 +174,33 @@ namespace Domain.Models.Audio
         /// <summary>
         /// Adds a performer to the song.
         /// </summary>
-        /// <param name="performerID">The unique identifier of the performer.</param>
+        /// <param name="performer">The performer to be add.</param>
         /// <returns>A <see cref="Result{TValue}"/> containing the added performer or an error.</returns>
-        public Result<PerformerSong> AddPerformer(Guid performerID)
+        public Result<PerformerSong> AddPerformer(SongPerformer performer)
         {
-            if (performerID == Guid.Empty)
-            {
-                return Result.Failure<PerformerSong>(new Error("Performer.Missing", "Performer is missing", ErrorType.Validation));
-            }
-            if (Performers.Any(p => p.PerformerID == performerID))
+            if (Performers.Any(p => p.Id == performer.Id))
             {
                 return Result.Failure<PerformerSong>(new Error("Performer.Exists", "Performer already added to song.", ErrorType.Failure));
             }
-            var performerSong = PerformerSong.Create(performerID, Id);
-            _performers.Add(performerSong.Value);
+            var performerSong = PerformerSong.Create(performer.Id, Id);
+            _performers.Add(performer);
             return Result.Success(performerSong.Value);
         }
 
         /// <summary>
         /// Removes a performer from the song.
         /// </summary>
-        /// <param name="performerID">The unique identifier of the performer.</param>
+        /// <param name="performer">The unique identifier of the performer.</param>
         /// <returns>A <see cref="Result{TValue}"/> containing the removed performer or an error.</returns>
-        public Result<PerformerSong> RemovePerformer(Guid performerID)
+        public Result<SongPerformer> RemovePerformer(SongPerformer performer)
         {
-            if (performerID == Guid.Empty)
+            var performerToRemove = Performers.FirstOrDefault(p => p.Id == performer.Id);
+            if (performerToRemove == null)
             {
-                return Result.Failure<PerformerSong>(new Error("Performer.Missing", "Performer is missing", ErrorType.Validation));
+                return Result.Failure<SongPerformer>(new Error("Performer.NotFound", "Performer not found in song.", ErrorType.NotFound));
             }
-            var performerSong = Performers.FirstOrDefault(p => p.PerformerID == performerID);
-            if (performerSong == null)
-            {
-                return Result.Failure<PerformerSong>(new Error("Performer.NotFound", "Performer not found in song.", ErrorType.NotFound));
-            }
-            _performers.Remove(performerSong);
-            return Result.Success(performerSong);
+            _performers.Remove(performerToRemove);
+            return Result.Success(performerToRemove);
         }
     }
 }

--- a/src/Domain/Models/Audio/SongPerformer.cs
+++ b/src/Domain/Models/Audio/SongPerformer.cs
@@ -18,7 +18,7 @@ namespace Domain.Models.Audio
         /// <param name="id"></param>
         private SongPerformer(Guid id) : base(id) { }
 
-        private HashSet<PerformerSong> _songs;
+        private HashSet<Song> _songs;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SongPerformer"/> class.
@@ -28,7 +28,7 @@ namespace Domain.Models.Audio
         private SongPerformer(Guid id, string performerName) : base(id)
         {
             PerformerName = performerName;
-            _songs = new HashSet<PerformerSong>();
+            _songs = new HashSet<Song>();
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Domain.Models.Audio
         /// Gets the collection of songs associated with the performer.
         /// </summary>
         [Display(Name = "Dalok")]
-        public virtual ICollection<PerformerSong> Songs => _songs.ToList();
+        public virtual ICollection<Song> Songs => _songs.ToList();
 
         /// <summary>
         /// Creates a new instance of the <see cref="SongPerformer"/> class.

--- a/tests/Domain.UnitTests/Audio/SongTests.cs
+++ b/tests/Domain.UnitTests/Audio/SongTests.cs
@@ -117,18 +117,18 @@ namespace Domain.UnitTests.Audio
         {
             // Arrange
             var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.NewGuid();
+            var performer = SongPerformer.Create("SongPerformer");
             // Act
-            var result = song.Value.AddPerformer(performerID);
+            var result = song.Value.AddPerformer(performer.Value);
             // Assert
             result.ShouldNotBeNull();
             result.IsFailure.ShouldBeFalse();
             result.IsSuccess.ShouldBeTrue();
             result.Value.ShouldNotBeNull();
-            result.Value.PerformerID.ShouldBe(performerID);
+            result.Value.PerformerID.ShouldBe(performer.Value.Id);
             result.Value.SongID.ShouldBe(song.Value.Id);
             song.Value.Performers.Count.ShouldNotBe(0);
-            song.Value.Performers.ShouldContain(result.Value);
+            song.Value.Performers.ShouldContain(performer.Value);
         }
 
         /// <summary>
@@ -136,23 +136,22 @@ namespace Domain.UnitTests.Audio
         /// <see cref="Song.RemovePerformer(Guid)"/>
         /// </summary>
         [Fact]
-        public void RemovePerformerShouldReturnPerformerSong()
+        public void RemovePerformerShouldReturnSongPerformer()
         {
             // Arrange
             var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.NewGuid();
-            song.Value.AddPerformer(performerID);
+            var performer = SongPerformer.Create("SongPerformer");
+            song.Value.AddPerformer(performer.Value);
             // Act
-            var result = song.Value.RemovePerformer(performerID);
+            var result = song.Value.RemovePerformer(performer.Value);
             // Assert
             result.ShouldNotBeNull();
             result.IsFailure.ShouldBeFalse();
             result.IsSuccess.ShouldBeTrue();
             result.Value.ShouldNotBeNull();
-            result.Value.PerformerID.ShouldBe(performerID);
-            result.Value.SongID.ShouldBe(song.Value.Id);
+            result.Value.Id.ShouldBe(performer.Value.Id);
             song.Value.Performers.Count.ShouldBe(0);
-            song.Value.Performers.ShouldNotContain(result.Value);
+            song.Value.Performers.ShouldNotContain(performer.Value);
         }
 
         /// <summary>
@@ -164,10 +163,10 @@ namespace Domain.UnitTests.Audio
         {
             // Arrange
             var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.NewGuid();
-            song.Value.AddPerformer(performerID);
+            var performer = SongPerformer.Create("SongPerformer");
+            song.Value.AddPerformer(performer.Value);
             // Act
-            var result = song.Value.AddPerformer(performerID);
+            var result = song.Value.AddPerformer(performer.Value);
             // Assert
             result.ShouldNotBeNull();
             result.IsFailure.ShouldBeTrue();
@@ -175,27 +174,6 @@ namespace Domain.UnitTests.Audio
             result.Error.Type.ShouldBe(ErrorType.Failure);
             result.Error.Code.ShouldBe("Performer.Exists");
             result.Error.Message.ShouldBe("Performer already added to song.");
-        }
-
-        /// <summary>
-        /// Empty performer ID should return error when adding performer.
-        /// <see cref="Song.AddPerformer(Guid)"/>"
-        /// </summary>
-        [Fact]
-        public void EmptyPerformerIDShouldReturnErrorWhenAddingPerformer()
-        {
-            // Arrange
-            var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.Empty;
-            // Act
-            var result = song.Value.AddPerformer(performerID);
-            // Assert
-            result.ShouldNotBeNull();
-            result.IsFailure.ShouldBeTrue();
-            result.IsSuccess.ShouldBeFalse();
-            result.Error.Type.ShouldBe(ErrorType.Validation);
-            result.Error.Code.ShouldBe("Performer.Missing");
-            result.Error.Message.ShouldBe("Performer is missing");
         }
 
         /// <summary>
@@ -207,9 +185,9 @@ namespace Domain.UnitTests.Audio
         {
             // Arrange
             var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.NewGuid();
+            var performer = SongPerformer.Create("SongPerformer");
             // Act
-            var result = song.Value.RemovePerformer(performerID);
+            var result = song.Value.RemovePerformer(performer.Value);
             // Assert
             result.ShouldNotBeNull();
             result.IsFailure.ShouldBeTrue();
@@ -217,27 +195,6 @@ namespace Domain.UnitTests.Audio
             result.Error.Type.ShouldBe(ErrorType.NotFound);
             result.Error.Code.ShouldBe("Performer.NotFound");
             result.Error.Message.ShouldBe("Performer not found in song.");
-        }
-
-        /// <summary>
-        /// Empty performer ID should return error when removing performer.
-        /// <see cref="Song.RemovePerformer(Guid)"/>"
-        /// </summary>
-        [Fact]
-        public void EmptyPerformerIDShouldReturnErrorWhenRemovingPerformer()
-        {
-            // Arrange
-            var song = Song.Create("Test song", "Test lyric", Guid.NewGuid(), Guid.NewGuid());
-            var performerID = Guid.Empty;
-            // Act
-            var result = song.Value.RemovePerformer(performerID);
-            // Assert
-            result.ShouldNotBeNull();
-            result.IsFailure.ShouldBeTrue();
-            result.IsSuccess.ShouldBeFalse();
-            result.Error.Type.ShouldBe(ErrorType.Validation);
-            result.Error.Code.ShouldBe("Performer.Missing");
-            result.Error.Message.ShouldBe("Performer is missing");
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request refactors the relationship between `Song` and `Performer` entities, replacing the intermediary `PerformerSong` class with direct associations using `SongPerformer`. It also updates the relevant unit tests to align with these changes. Key changes include updates to the data model, method signatures, and test cases.

### Model Refactoring

* Replaced `PerformerSong` with `SongPerformer` in the `Song` class for managing performer associations. This includes updates to the private `_performers` field, public `Performers` property, and methods like `AddPerformer` and `RemovePerformer` to use `SongPerformer` directly. [[1]](diffhunk://#diff-8278eca7caeb00cbc391e974dc6853b25c79035fbf69f9e10d18f4b43b584d5fL22-R22) [[2]](diffhunk://#diff-8278eca7caeb00cbc391e974dc6853b25c79035fbf69f9e10d18f4b43b584d5fL39-R39) [[3]](diffhunk://#diff-8278eca7caeb00cbc391e974dc6853b25c79035fbf69f9e10d18f4b43b584d5fL82-R82) [[4]](diffhunk://#diff-8278eca7caeb00cbc391e974dc6853b25c79035fbf69f9e10d18f4b43b584d5fL177-R203)
* Updated the `SongPerformer` class to directly associate with `Song` instead of `PerformerSong`, modifying the `_songs` field and `Songs` property accordingly. [[1]](diffhunk://#diff-2c2c59e377ac17a7202d96c5232a6da7b5e51d21cf315a47d0134a8bfb5a5b22L21-R21) [[2]](diffhunk://#diff-2c2c59e377ac17a7202d96c5232a6da7b5e51d21cf315a47d0134a8bfb5a5b22L31-R31) [[3]](diffhunk://#diff-2c2c59e377ac17a7202d96c5232a6da7b5e51d21cf315a47d0134a8bfb5a5b22L45-R45)

### Unit Test Updates

* Refactored test cases in `SongTests` to use `SongPerformer` instead of `PerformerSong`, including updates to `AddPerformerShouldReturnPerformerSong` and `RemovePerformerShouldReturnPerformerSong`. [[1]](diffhunk://#diff-b9d0238d70fe6a5a294bd3b0199f7b2c32fb528fd2d910d9e3d35a9e7208f3edL120-R154) [[2]](diffhunk://#diff-b9d0238d70fe6a5a294bd3b0199f7b2c32fb528fd2d910d9e3d35a9e7208f3edL167-R169)
* Removed test cases for scenarios involving empty performer IDs, as these validations are no longer applicable with the new `SongPerformer` model. [[1]](diffhunk://#diff-b9d0238d70fe6a5a294bd3b0199f7b2c32fb528fd2d910d9e3d35a9e7208f3edL180-L200) [[2]](diffhunk://#diff-b9d0238d70fe6a5a294bd3b0199f7b2c32fb528fd2d910d9e3d35a9e7208f3edL222-L242)